### PR TITLE
Proposed review changes for #1578

### DIFF
--- a/improver/ensemble_copula_coupling/utilities.py
+++ b/improver/ensemble_copula_coupling/utilities.py
@@ -308,19 +308,28 @@ def slow_interp_same_y(x: np.ndarray, xp: np.ndarray, fp: np.ndarray) -> np.ndar
     return result
 
 
-try:
-    import numba  # noqa: F401
+def interpolate_multiple_rows_same_y(*args):
+    """For each row i of xp, do the equivalent of np.interp(x, xp[i], fp).
 
-    from improver.ensemble_copula_coupling.numba_utilities import fast_interp_same_y
+    Calls a fast numba implementation where numba is available (see
+    `improver.ensemble_copula_coupling.numba_utilities.fast_interp_same_y`) and calls a
+    the native python implementation otherwise (see :func:`slow_interp_same_y`).
 
-    def interpolate_multiple_rows_same_y(*args):
+    Args:
+        x: 1-d array
+        xp: n * m array, each row must be in non-decreasing order
+        fp: 1-d array with length m
+    Returns:
+        n * len(x) array where each row i is equal to np.interp(x, xp[i], fp)
+    """
+    try:
+        import numba  # noqa: F401
+
+        from improver.ensemble_copula_coupling.numba_utilities import fast_interp_same_y
+
         return fast_interp_same_y(*args)
-
-
-except ImportError:
-    warnings.warn(
-        "Module numba unavailable. ConvertProbabilitiesToPercentiles will be slower."
-    )
-
-    def interpolate_multiple_rows_same_y(*args):
+    except ImportError:
+        warnings.warn(
+            "Module numba unavailable. ConvertProbabilitiesToPercentiles will be slower."
+        )
         return slow_interp_same_y(*args)


### PR DESCRIPTION
- Creates a public function `interpolate_multiple_rows_same_y`, documenting the conditions of change of behaviour between numba vs no numba availability.
- mock is part of unittest in recent Python, not an independent library.  So corrected this.
- Alternative (I think simpler) approach to checking what implementation is used when numba is available or not in the testing.